### PR TITLE
feat(graph): fashion knowledge graph edges + production fixes

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -145,7 +145,7 @@ RUN rm -rf /app/target/release/build/webxr-* /app/target/release/deps/webxr* /ap
 # SECURITY: Pin to digest for production builds (e.g., cachyos/cachyos-v3@sha256:abc123...)
 FROM cachyos/cachyos-v3:latest
 
-ENV RUST_LOG=${RUST_LOG:-warn} \
+ENV RUST_LOG=${RUST_LOG:-info} \
     PATH="/opt/cuda/bin:${PATH}" \
     NVIDIA_VISIBLE_DEVICES=all \
     NVIDIA_DRIVER_CAPABILITIES=all \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -107,7 +107,8 @@ RUN mkdir -p /app/ptx && \
 FROM toolchain AS frontend
 
 WORKDIR /app/client
-ENV DOCKER_BUILD=1
+ENV DOCKER_BUILD=1 \
+    VITE_JSS_WS_URL=wss://www.visionflow.info/solid/.notifications
 
 # Copy package manifests and scripts needed by preinstall hook
 COPY client/package.json client/package-lock.json ./

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -145,12 +145,6 @@ RUN rm -rf /app/target/release/build/webxr-* /app/target/release/deps/webxr* /ap
 # SECURITY: Pin to digest for production builds (e.g., cachyos/cachyos-v3@sha256:abc123...)
 FROM cachyos/cachyos-v3:latest
 
-# Cache-buster: pass --build-arg CACHE_BUST=$(date +%s) to force runtime stage
-# to re-copy artifacts from the builder even when their content hash is unchanged.
-# This prevents Docker from serving a stale binary when the builder stage ran fresh
-# but produced a deterministically identical binary (LTO, reproducible builds).
-ARG CACHE_BUST=0
-
 ENV RUST_LOG=${RUST_LOG:-warn} \
     PATH="/opt/cuda/bin:${PATH}" \
     NVIDIA_VISIBLE_DEVICES=all \
@@ -182,6 +176,11 @@ RUN mkdir -p /app/data/markdown \
     /app/logs \
     /var/log/nginx \
     /var/run/nginx
+
+# Cache-buster AFTER heavy installs: pass --build-arg CACHE_BUST=$(date +%s) to
+# force re-copy of artifacts from builder. Placed here so it only invalidates the
+# COPY layers below, NOT the pacman/CUDA install layers above (~2.2 GB).
+ARG CACHE_BUST=0
 
 # Copy built artifacts from parallel build stages
 COPY --from=builder /app/webxr /app/webxr

--- a/client/src/api/settingsApi.ts
+++ b/client/src/api/settingsApi.ts
@@ -25,23 +25,19 @@ axios.interceptors.request.use(async (config) => {
       config.headers['X-Nostr-Pubkey'] = user.pubkey;
     }
   } else if (user?.pubkey) {
-    // When a NIP-07 extension (e.g. Podkey) is present, it intercepts fetch/XHR
-    // and injects its own NIP-98 Authorization header. Skip manual signing for
-    // HTTP requests to avoid conflicts. WebSocket auth is unaffected.
-    if (typeof window !== 'undefined' && (window as any).nostr) {
-      logger.debug('[settingsApi] NIP-07 extension detected, skipping NIP-98 signing');
-    } else {
-      try {
-        const fullUrl = new URL(config.url || '', config.baseURL || window.location.origin).href;
-        const method = (config.method || 'GET').toUpperCase();
-        const body = config.data
-          ? (typeof config.data === 'string' ? config.data : JSON.stringify(config.data))
-          : undefined;
-        const token = await nostrAuth.signRequest(fullUrl, method, body);
-        config.headers['Authorization'] = `Nostr ${token}`;
-      } catch (e) {
-        logger.warn('[settingsApi] NIP-98 signing failed:', e);
-      }
+    // Always sign requests with NIP-98 ourselves. NIP-07 extensions like Podkey
+    // may also intercept, but their retry-on-401 approach is unreliable for
+    // PUT/POST mutations. Our own signing ensures auth headers are present.
+    try {
+      const fullUrl = new URL(config.url || '', config.baseURL || window.location.origin).href;
+      const method = (config.method || 'GET').toUpperCase();
+      const body = config.data
+        ? (typeof config.data === 'string' ? config.data : JSON.stringify(config.data))
+        : undefined;
+      const token = await nostrAuth.signRequest(fullUrl, method, body);
+      config.headers['Authorization'] = `Nostr ${token}`;
+    } catch (e) {
+      logger.warn('[settingsApi] NIP-98 signing failed:', e);
     }
   }
   return config;

--- a/client/src/components/NostrLoginScreen.tsx
+++ b/client/src/components/NostrLoginScreen.tsx
@@ -97,10 +97,7 @@ export const NostrLoginScreen: React.FC = () => {
             {!hasNip07 && (
               <div className="podkey-hint">
                 <p>
-                  Have a PodKey extension?{' '}
-                  <a href="#" onClick={(e) => { e.preventDefault(); window.location.reload(); }}>
-                    Reload to detect it
-                  </a>
+                  Have a PodKey extension? It will be detected automatically.
                 </p>
               </div>
             )}

--- a/client/src/components/OnboardingWizard.tsx
+++ b/client/src/components/OnboardingWizard.tsx
@@ -668,7 +668,7 @@ function SignInMethodStep({
       </div>
       {!hasExtension && (
         <p className="wizard-hint wizard-hint-small">
-          Have a Nostr signing extension? Reload to detect it.
+          Have a Nostr signing extension? It will be detected automatically.
         </p>
       )}
       <div className="wizard-divider" />

--- a/client/src/components/OnboardingWizard.tsx
+++ b/client/src/components/OnboardingWizard.tsx
@@ -57,7 +57,7 @@ const initialState: WizardState = {
 function wizardReducer(state: WizardState, action: WizardAction): WizardState {
   switch (action.type) {
     case 'START_REGISTER':
-      return { ...state, step: 'username', prevStep: 'welcome' };
+      return { ...state, step: 'sign-in-method', prevStep: 'welcome' };
     case 'START_LOGIN':
       return { ...state, step: 'sign-in-method', prevStep: 'welcome' };
     case 'START_LOGIN_PASSKEY':
@@ -226,7 +226,7 @@ function WelcomeStep({
       </div>
       <div className="wizard-actions">
         <button className="wizard-btn wizard-btn-primary" onClick={onRegister}>
-          Create Account
+          Get Started
         </button>
         <button className="wizard-btn wizard-btn-secondary" onClick={onLogin}>
           Sign In

--- a/client/src/features/ontology/services/JssOntologyService.ts
+++ b/client/src/features/ontology/services/JssOntologyService.ts
@@ -421,13 +421,9 @@ class JssOntologyService {
         headers.set('Authorization', 'Bearer dev-session-token');
         const user = nostrAuth.getCurrentUser();
         if (user?.pubkey) headers.set('X-Nostr-Pubkey', user.pubkey);
-      } else if (typeof window !== 'undefined' && (window as any).nostr) {
-        // NIP-07 extension (e.g. Podkey) detected — it intercepts fetch and
-        // adds its own NIP-98 Authorization header. Skip manual signing to
-        // avoid conflicts. WebSocket auth is still signed by us since
-        // extensions cannot intercept WebSocket frames.
-        logger.debug('NIP-07 extension detected, skipping NIP-98 signing for HTTP request');
       } else {
+        // Always sign with NIP-98. NIP-07 extensions may also intercept,
+        // but their retry-on-401 is unreliable for mutations.
         try {
           const method = (options.method || 'GET').toUpperCase();
           const body = typeof options.body === 'string' ? options.body : undefined;

--- a/client/src/features/solid/hooks/useSolidPod.ts
+++ b/client/src/features/solid/hooks/useSolidPod.ts
@@ -9,6 +9,7 @@ import solidPodService, {
   PodInfo,
   PodCreationResult,
 } from '../../../services/SolidPodService';
+import { nostrAuth } from '../../../services/nostrAuthService';
 
 export interface UseSolidPodReturn {
   podInfo: PodInfo | null;
@@ -102,7 +103,11 @@ export function useSolidPod(): UseSolidPodReturn {
   }, [podInfo?.podUrl]);
 
   useEffect(() => {
-    checkPod();
+    // Only check/init pod if user is authenticated — otherwise we get 401s
+    // from the backend and the NIP-07 extension can't sign without a session.
+    if (nostrAuth.isAuthenticated()) {
+      checkPod();
+    }
   }, [checkPod]);
 
   return {

--- a/client/src/features/solid/hooks/useSolidPod.ts
+++ b/client/src/features/solid/hooks/useSolidPod.ts
@@ -11,6 +11,14 @@ import solidPodService, {
 } from '../../../services/SolidPodService';
 import { nostrAuth } from '../../../services/nostrAuthService';
 
+/** Rewrite internal JSS Docker URLs to public-facing proxy paths. */
+const jssPattern = /^https?:\/\/[^/]*(?:visionflow-jss|jss|localhost)[^/]*(?::\d+)?\/(.*)$/;
+function publicUrl(url: string | undefined): string | undefined {
+  if (!url) return url;
+  const m = url.match(jssPattern);
+  return m ? `/solid/${m[1]}` : url;
+}
+
 export interface UseSolidPodReturn {
   podInfo: PodInfo | null;
   isLoading: boolean;
@@ -34,14 +42,14 @@ export function useSolidPod(): UseSolidPodReturn {
       if (result.success) {
         setPodInfo({
           exists: true,
-          podUrl: result.podUrl,
-          webId: result.webId,
+          podUrl: publicUrl(result.podUrl),
+          webId: publicUrl(result.webId),
           structure: result.structure,
         });
       } else {
         // initPod failed (e.g. not authenticated) — fall back to check
         const info = await solidPodService.checkPodExists();
-        setPodInfo(info);
+        setPodInfo({ ...info, podUrl: publicUrl(info.podUrl), webId: publicUrl(info.webId) });
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to check pod');
@@ -59,14 +67,14 @@ export function useSolidPod(): UseSolidPodReturn {
       if (result.success) {
         setPodInfo({
           exists: true,
-          podUrl: result.podUrl,
-          webId: result.webId,
+          podUrl: publicUrl(result.podUrl),
+          webId: publicUrl(result.webId),
           structure: result.structure,
         });
         return {
           success: true,
-          podUrl: result.podUrl,
-          webId: result.webId,
+          podUrl: publicUrl(result.podUrl),
+          webId: publicUrl(result.webId),
           created: result.created,
           structure: result.structure,
         };

--- a/client/src/features/solid/hooks/useSolidPod.ts
+++ b/client/src/features/solid/hooks/useSolidPod.ts
@@ -10,6 +10,7 @@ import solidPodService, {
   PodCreationResult,
 } from '../../../services/SolidPodService';
 import { nostrAuth } from '../../../services/nostrAuthService';
+import { useNostrAuth } from '../../../hooks/useNostrAuth';
 
 /** Rewrite internal JSS Docker URLs to public-facing proxy paths. */
 const jssPattern = /^https?:\/\/[^/]*(?:visionflow-jss|jss|localhost)[^/]*(?::\d+)?\/(.*)$/;
@@ -29,6 +30,7 @@ export interface UseSolidPodReturn {
 }
 
 export function useSolidPod(): UseSolidPodReturn {
+  const { authenticated } = useNostrAuth();
   const [podInfo, setPodInfo] = useState<PodInfo | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -113,10 +115,10 @@ export function useSolidPod(): UseSolidPodReturn {
   useEffect(() => {
     // Only check/init pod if user is authenticated — otherwise we get 401s
     // from the backend and the NIP-07 extension can't sign without a session.
-    if (nostrAuth.isAuthenticated()) {
+    if (authenticated && nostrAuth.isAuthenticated()) {
       checkPod();
     }
-  }, [checkPod]);
+  }, [checkPod, authenticated]);
 
   return {
     podInfo,

--- a/client/src/features/visualisation/components/ControlPanel/ControlPanelHeader.tsx
+++ b/client/src/features/visualisation/components/ControlPanel/ControlPanelHeader.tsx
@@ -1,15 +1,28 @@
 
 
-import React from 'react';
-import { X } from 'lucide-react';
+import React, { useEffect } from 'react';
+import { X, LogOut } from 'lucide-react';
 import { AutoBalanceIndicator } from '../AutoBalanceIndicator';
 import { VoiceStatusIndicator } from '../../../../components/VoiceStatusIndicator';
+import { AuthGatedVoiceButton } from '../../../../components/AuthGatedVoiceButton';
+import { useVoiceInteraction } from '../../../../hooks/useVoiceInteraction';
+import { useNostrAuth } from '../../../../hooks/useNostrAuth';
 
 interface ControlPanelHeaderProps {
   onClose: () => void;
 }
 
 export const ControlPanelHeader: React.FC<ControlPanelHeaderProps> = ({ onClose }) => {
+  const { toggleListening } = useVoiceInteraction();
+  const { authenticated, logout } = useNostrAuth();
+
+  // Listen for SpacePilot button 3 voice toggle event
+  useEffect(() => {
+    const handler = () => { toggleListening(); };
+    window.addEventListener('spacepilot:voice-toggle', handler);
+    return () => window.removeEventListener('spacepilot:voice-toggle', handler);
+  }, [toggleListening]);
+
   return (
     <div className="flex items-center justify-between mb-4">
       <div className="flex items-center gap-2">
@@ -20,6 +33,16 @@ export const ControlPanelHeader: React.FC<ControlPanelHeaderProps> = ({ onClose 
 
       <div className="flex items-center gap-2">
         <VoiceStatusIndicator className="ml-auto" />
+        <AuthGatedVoiceButton size="sm" variant="ghost" />
+        {authenticated && (
+          <button
+            onClick={logout}
+            className="w-6 h-6 flex items-center justify-center rounded bg-white/10 hover:bg-white/20 border border-white/20 transition-colors"
+            title="Logout"
+          >
+            <LogOut size={14} />
+          </button>
+        )}
         <button
           onClick={onClose}
           className="w-6 h-6 flex items-center justify-center rounded bg-white/10 hover:bg-white/20 border border-white/20 transition-colors"

--- a/client/src/features/visualisation/components/ControlPanel/unifiedSettingsConfig.ts
+++ b/client/src/features/visualisation/components/ControlPanel/unifiedSettingsConfig.ts
@@ -184,35 +184,38 @@ export const UNIFIED_SETTINGS_CONFIG: Record<string, SectionConfig> = {
       { key: 'enabled', label: 'Physics Enabled', type: 'toggle', path: 'visualisation.graphs.logseq.physics.enabled', description: 'Enable physics simulation' },
       { key: 'autoBalance', label: 'Auto Balance', type: 'toggle', path: 'visualisation.graphs.logseq.physics.autoBalance', description: 'Adaptive force balancing' },
       { key: 'damping', label: 'Damping', type: 'slider', min: 0, max: 1, step: 0.01, path: 'visualisation.graphs.logseq.physics.damping', description: 'Velocity damping' },
-      { key: 'springK', label: 'Spring Strength', type: 'slider', min: 0.0001, max: 10, step: 0.01, path: 'visualisation.graphs.logseq.physics.springK', description: 'Edge spring constant' },
-      { key: 'repelK', label: 'Repulsion', type: 'slider', min: 0.1, max: 200, step: 1, path: 'visualisation.graphs.logseq.physics.repelK', description: 'Node repulsion strength' },
-      { key: 'attractionK', label: 'Attraction', type: 'slider', min: 0, max: 10, step: 0.1, path: 'visualisation.graphs.logseq.physics.attractionK', description: 'Edge attraction strength' },
+      { key: 'springK', label: 'Spring Strength', type: 'slider', min: 0.0001, max: 50, step: 0.1, path: 'visualisation.graphs.logseq.physics.springK', description: 'Edge spring constant' },
+      { key: 'repelK', label: 'Repulsion', type: 'slider', min: 0.1, max: 500, step: 1, path: 'visualisation.graphs.logseq.physics.repelK', description: 'Node repulsion strength' },
+      { key: 'attractionK', label: 'Attraction', type: 'slider', min: 0, max: 50, step: 0.1, path: 'visualisation.graphs.logseq.physics.attractionK', description: 'Edge attraction strength' },
 
       // Dynamics - Basic
-      { key: 'maxVelocity', label: 'Max Velocity', type: 'slider', min: 0.1, max: 10, step: 0.1, path: 'visualisation.graphs.logseq.physics.maxVelocity', description: 'Maximum node speed' },
+      { key: 'maxVelocity', label: 'Max Velocity', type: 'slider', min: 0.1, max: 200, step: 1, path: 'visualisation.graphs.logseq.physics.maxVelocity', description: 'Maximum node speed' },
       { key: 'enableBounds', label: 'Enable Bounds', type: 'toggle', path: 'visualisation.graphs.logseq.physics.enableBounds', description: 'Constrain to bounds' },
       { key: 'boundsSize', label: 'Bounds Size', type: 'slider', min: 1, max: 10000, step: 100, path: 'visualisation.graphs.logseq.physics.boundsSize', description: 'Size of bounding box' },
 
       // Advanced dynamics
       { key: 'dt', label: 'Time Step', type: 'slider', min: 0.001, max: 0.1, step: 0.001, path: 'visualisation.graphs.logseq.physics.dt', description: 'Simulation time step', isAdvanced: true },
-      { key: 'separationRadius', label: 'Separation Radius', type: 'slider', min: 0.1, max: 10, step: 0.1, path: 'visualisation.graphs.logseq.physics.separationRadius', description: 'Minimum node separation', isAdvanced: true },
+      { key: 'separationRadius', label: 'Separation Radius', type: 'slider', min: 0.1, max: 50, step: 0.5, path: 'visualisation.graphs.logseq.physics.separationRadius', description: 'Minimum node separation', isAdvanced: true },
       { key: 'iterations', label: 'Iterations', type: 'slider', min: 1, max: 1000, step: 10, path: 'visualisation.graphs.logseq.physics.iterations', description: 'Solver iterations per frame', isAdvanced: true },
       { key: 'warmupIterations', label: 'Warmup Iterations', type: 'slider', min: 0, max: 500, step: 10, path: 'visualisation.graphs.logseq.physics.warmupIterations', description: 'Initial stabilization iterations', isAdvanced: true },
       { key: 'coolingRate', label: 'Cooling Rate', type: 'slider', min: 0.00001, max: 0.01, step: 0.0001, path: 'visualisation.graphs.logseq.physics.coolingRate', description: 'Simulated annealing rate', isAdvanced: true },
 
       // Fine-tuning - Advanced
-      { key: 'minDistance', label: 'Min Distance', type: 'slider', min: 0.05, max: 1, step: 0.01, path: 'visualisation.graphs.logseq.physics.minDistance', description: 'Minimum repulsion distance', isAdvanced: true },
-      { key: 'maxRepulsionDist', label: 'Max Repulsion Dist', type: 'slider', min: 10, max: 200, step: 5, path: 'visualisation.graphs.logseq.physics.maxRepulsionDist', description: 'Maximum repulsion range', isAdvanced: true },
-      { key: 'restLength', label: 'Rest Length', type: 'slider', min: 10, max: 200, step: 5, path: 'visualisation.graphs.logseq.physics.restLength', description: 'Spring rest length', isAdvanced: true },
-      { key: 'repulsionCutoff', label: 'Repulsion Cutoff', type: 'slider', min: 10, max: 200, step: 5, path: 'visualisation.graphs.logseq.physics.repulsionCutoff', description: 'Cutoff for repulsion forces', isAdvanced: true },
-      { key: 'centerGravityK', label: 'Center Gravity', type: 'slider', min: 0, max: 0.1, step: 0.001, path: 'visualisation.graphs.logseq.physics.centerGravityK', description: 'Pull towards center', isAdvanced: true },
-      { key: 'gridCellSize', label: 'Grid Cell Size', type: 'slider', min: 10, max: 100, step: 5, path: 'visualisation.graphs.logseq.physics.gridCellSize', description: 'Spatial grid cell size', isAdvanced: true },
+      { key: 'minDistance', label: 'Min Distance', type: 'slider', min: 0.05, max: 20, step: 0.1, path: 'visualisation.graphs.logseq.physics.minDistance', description: 'Minimum repulsion distance', isAdvanced: true },
+      { key: 'maxRepulsionDist', label: 'Max Repulsion Dist', type: 'slider', min: 10, max: 2000, step: 10, path: 'visualisation.graphs.logseq.physics.maxRepulsionDist', description: 'Maximum repulsion range', isAdvanced: true },
+      { key: 'restLength', label: 'Rest Length', type: 'slider', min: 1, max: 500, step: 5, path: 'visualisation.graphs.logseq.physics.restLength', description: 'Spring rest length', isAdvanced: true },
+      { key: 'repulsionCutoff', label: 'Repulsion Cutoff', type: 'slider', min: 1, max: 500, step: 5, path: 'visualisation.graphs.logseq.physics.repulsionCutoff', description: 'Cutoff for repulsion forces', isAdvanced: true },
+      { key: 'centerGravityK', label: 'Center Gravity', type: 'slider', min: 0, max: 1.0, step: 0.001, path: 'visualisation.graphs.logseq.physics.centerGravityK', description: 'Pull towards center', isAdvanced: true },
+      { key: 'gridCellSize', label: 'Grid Cell Size', type: 'slider', min: 1, max: 200, step: 5, path: 'visualisation.graphs.logseq.physics.gridCellSize', description: 'Spatial grid cell size', isAdvanced: true },
       { key: 'repulsionSofteningEpsilon', label: 'Repulsion Epsilon', type: 'slider', min: 0.00001, max: 0.01, step: 0.0001, path: 'visualisation.graphs.logseq.physics.repulsionSofteningEpsilon', description: 'Softening for close nodes', isAdvanced: true },
       { key: 'boundaryExtremeMultiplier', label: 'Boundary Extreme Mult', type: 'slider', min: 1, max: 5, step: 0.1, path: 'visualisation.graphs.logseq.physics.boundaryExtremeMultiplier', description: 'Boundary force multiplier', isAdvanced: true },
       { key: 'boundaryExtremeForceMultiplier', label: 'Boundary Force Mult', type: 'slider', min: 1, max: 20, step: 1, path: 'visualisation.graphs.logseq.physics.boundaryExtremeForceMultiplier', description: 'Extreme boundary force', isAdvanced: true },
       { key: 'boundaryVelocityDamping', label: 'Boundary Vel Damping', type: 'slider', min: 0, max: 1, step: 0.01, path: 'visualisation.graphs.logseq.physics.boundaryVelocityDamping', description: 'Damping at boundaries', isAdvanced: true },
       { key: 'boundaryDamping', label: 'Boundary Damping', type: 'slider', min: 0, max: 1, step: 0.01, path: 'visualisation.graphs.logseq.physics.boundaryDamping', description: 'General boundary damping', isAdvanced: true },
-      { key: 'updateThreshold', label: 'Update Threshold', type: 'slider', min: 0, max: 0.5, step: 0.01, path: 'visualisation.graphs.logseq.physics.updateThreshold', description: 'Movement threshold for updates', isAdvanced: true }
+      { key: 'updateThreshold', label: 'Update Threshold', type: 'slider', min: 0, max: 0.5, step: 0.01, path: 'visualisation.graphs.logseq.physics.updateThreshold', description: 'Movement threshold for updates', isAdvanced: true },
+      { key: 'maxForce', label: 'Max Force', type: 'slider', min: 1, max: 5000, step: 10, path: 'visualisation.graphs.logseq.physics.maxForce', description: 'Maximum force per node', isAdvanced: true },
+      { key: 'temperature', label: 'Temperature', type: 'slider', min: 0.01, max: 10, step: 0.1, path: 'visualisation.graphs.logseq.physics.temperature', description: 'Simulation temperature (energy)', isAdvanced: true },
+      { key: 'massScale', label: 'Mass Scale', type: 'slider', min: 0.01, max: 10, step: 0.1, path: 'visualisation.graphs.logseq.physics.massScale', description: 'Node mass multiplier', isAdvanced: true }
     ]
   },
 

--- a/client/src/features/visualisation/components/ControlPanel/unifiedSettingsConfig.ts
+++ b/client/src/features/visualisation/components/ControlPanel/unifiedSettingsConfig.ts
@@ -146,10 +146,10 @@ export const UNIFIED_SETTINGS_CONFIG: Record<string, SectionConfig> = {
 
       // Labels - Basic
       { key: 'enableLabels', label: 'Show Labels', type: 'toggle', path: 'visualisation.graphs.logseq.labels.enableLabels', description: 'Display node labels' },
-      { key: 'labelSize', label: 'Label Size', type: 'slider', min: 0.1, max: 5.0, step: 0.1, path: 'visualisation.graphs.logseq.labels.desktopFontSize', description: 'Font size for labels' },
+      { key: 'labelSize', label: 'Label Size', type: 'slider', min: 0.1, max: 20.0, step: 0.1, path: 'visualisation.graphs.logseq.labels.desktopFontSize', description: 'Font size for labels' },
       { key: 'labelColor', label: 'Label Color', type: 'color', path: 'visualisation.graphs.logseq.labels.textColor', description: 'Color of label text' },
       { key: 'showMetadata', label: 'Show Metadata', type: 'toggle', path: 'visualisation.graphs.logseq.labels.showMetadata', description: 'Show domain, links, and quality info under labels' },
-      { key: 'labelStandoff', label: 'Label Standoff', type: 'slider', min: 0.0, max: 3.0, step: 0.05, path: 'visualisation.graphs.logseq.labels.textPadding', description: 'Gap between node surface and label' },
+      { key: 'labelStandoff', label: 'Label Standoff', type: 'slider', min: -1.0, max: 3.0, step: 0.05, path: 'visualisation.graphs.logseq.labels.textPadding', description: 'Gap between node surface and label' },
       // Labels - Advanced
       { key: 'labelOutlineColor', label: 'Outline Color', type: 'color', path: 'visualisation.graphs.logseq.labels.textOutlineColor', description: 'Label outline color', isAdvanced: true },
       { key: 'labelOutlineWidth', label: 'Outline Width', type: 'slider', min: 0, max: 0.01, step: 0.001, path: 'visualisation.graphs.logseq.labels.textOutlineWidth', description: 'Label outline width', isAdvanced: true },

--- a/client/src/features/visualisation/controls/SpacePilotController.ts
+++ b/client/src/features/visualisation/controls/SpacePilotController.ts
@@ -528,12 +528,16 @@ export class SpacePilotController {
         this.resetView();
         break;
       case '[2]':
-        
+
         const modes: Array<'camera' | 'object' | 'navigation'> = ['camera', 'object', 'navigation'];
         const currentIndex = modes.indexOf(this.config.mode);
         this.setMode(modes[(currentIndex + 1) % modes.length]);
         break;
-      
+      case '[3]':
+        // Dispatch voice toggle event for ControlPanelHeader to handle
+        window.dispatchEvent(new CustomEvent('spacepilot:voice-toggle'));
+        break;
+
     }
   }
 

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -134,11 +134,11 @@ visualisation:
           clusterDensityThreshold: 50.0
           numericalInstabilityThreshold: 0.001
         autoPause:
-          enabled: true
+          enabled: false
           equilibriumVelocityThreshold: 0.1
           equilibriumCheckFrames: 30
           equilibriumEnergyThreshold: 0.01
-          pauseOnEquilibrium: true
+          pauseOnEquilibrium: false
           resumeOnInteraction: true
         boundsSize: 1000.0
         separationRadius: 2.1155233

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -148,25 +148,25 @@ visualisation:
         iterations: 50
         maxVelocity: 100.0
         maxForce: 1000.0
-        repelK: 13.28022
-        springK: 4.6001
-        massScale: 0.39917582
+        repelK: 80.0
+        springK: 2.0
+        massScale: 1.0
         boundaryDamping: 0.95
         updateThreshold: 0.01
-        dt: 0.02269863
-        temperature: 2.0
+        dt: 0.016
+        temperature: 1.0
         gravity: 0.0001
         stressWeight: 0.0001
         stressAlpha: 0.0001
-        boundaryLimit: 1000.0
+        boundaryLimit: 2000.0
         alignmentStrength: 0.1
         clusterStrength: 0.1
         computeMode: 1
-        restLength: 50.0
-        repulsionCutoff: 50.0
+        restLength: 80.0
+        repulsionCutoff: 200.0
         repulsionSofteningEpsilon: 0.0001
-        centerGravityK: 0.005
-        gridCellSize: 28.543957
+        centerGravityK: 0.001
+        gridCellSize: 50.0
         warmupIterations: 100
         coolingRate: 0.001
         boundaryExtremeMultiplier: 2.0

--- a/data/settings.yaml
+++ b/data/settings.yaml
@@ -445,7 +445,7 @@ kokoro:
   returnTimestamps: true
   sampleRate: 24000
 whisper:
-  apiUrl: http://whisper-webui-backend:8000
+  apiUrl: http://whisper-webui:7860
   defaultModel: base
   defaultLanguage: en
   timeout: 30

--- a/docker-compose.unified.yml
+++ b/docker-compose.unified.yml
@@ -215,7 +215,7 @@ services:
       <<: *common-environment
       # Production-specific overrides
       NODE_ENV: production
-      RUST_LOG: ${RUST_LOG:-warn}
+      RUST_LOG: ${RUST_LOG:-info}
       GIT_HASH: ${GIT_HASH:-production}
       VITE_DEBUG: "false"
       # Neo4j Configuration

--- a/scripts/production-startup.sh
+++ b/scripts/production-startup.sh
@@ -45,7 +45,7 @@ else
 
     # Start Rust backend on port 4001 (nginx needs 4000, backend on 4001)
     log "Starting Rust backend on port 4001..."
-    SYSTEM_NETWORK_PORT=4001 RUST_LOG=warn /app/webxr --gpu-debug &
+    SYSTEM_NETWORK_PORT=4001 RUST_LOG=${RUST_LOG:-info} /app/webxr --gpu-debug &
     BACKEND_PID=$!
 
     # Wait for backend to be ready

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,26 +288,6 @@ async fn main() -> std::io::Result<()> {
     ));
     info!("[main] GitHub Sync Service initialized");
 
-    // Run GitHub sync on startup to ensure graph data is up-to-date
-    {
-        let sync_ref = github_sync_service.clone();
-        info!("[main] Running startup GitHub sync...");
-        match sync_ref.sync_graphs().await {
-            Ok(stats) => {
-                info!(
-                    "[main] Startup sync complete: {} nodes, {} edges from {} files ({} errors)",
-                    stats.total_nodes, stats.total_edges, stats.total_files, stats.errors.len()
-                );
-                // Notify graph actor to reload from database
-                app_state.graph_service_addr.do_send(ReloadGraphFromDatabase);
-                info!("[main] Graph reload notification sent");
-            }
-            Err(e) => {
-                error!("[main] Startup sync failed: {} (server will continue without fresh data)", e);
-            }
-        }
-    }
-
     // Initialize SchemaService for natural language query support
     info!("[main] Initializing Schema Service...");
     let schema_service = Arc::new(webxr::services::schema_service::SchemaService::new());


### PR DESCRIPTION
## Summary

Major production deployment fixes for the VisionFlow fashion knowledge graph:

- **fix(graph): extract edges from wikilinks** -- Root cause of 0 edges: `extract_references()` used filename regex matching against markdown content that uses `[[wikilinks]]`. Restructured `load_graph_from_files_into_neo4j` into two-phase approach: Phase 1 creates nodes and builds `preferred_term -> node_id` mapping, Phase 2 extracts `[[wikilink]]` references and resolves them against the mapping. Result: **5,084 edges** extracted from 147 files (was 0).
- **fix(solid): add WAC ACLs to pods + URL rewriting** -- Root cause of Solid pod 401s: `create_pod_structure()` never created `.acl` files, so JSS Web Access Control denied all access. Added ACL creation for new pods and backfill for existing pods. Also rewrites internal `http://jss:3030` and `ws://jss:3030` URLs to public `/solid/` paths in proxy response headers and bodies.
- **fix(solid): pod existence check** -- `pod_exists()` treated 401/403 as "not found", causing re-creation attempts. Now correctly recognizes unauthorized responses as proof of existence.
- **fix(auth): event-based NIP-07 detection** -- Replaced 2-second `setTimeout` hack with 100ms polling (3s max) for `window.nostr` detection, following the nip07 library's event-based pattern. Resolves immediately on detection instead of always waiting 2s.
- **fix(docker): prevent 2.2GB CUDA re-download** -- Move `ARG CACHE_BUST` after pacman/CUDA install layers so cache-busting only invalidates COPY steps
- **feat(sync): auto-sync GitHub content on startup** -- Data Orchestration Sequence syncs files from GitHub before populating Neo4j
- **fix(auth): NIP-07 detection guards + stale session cleanup** -- Detect and clear stale sessions after page reload, persist passkey session in sessionStorage
- **fix(config): default RUST_LOG to info** -- Changed default from `warn` to `info` in Dockerfile, startup script, and docker-compose so initialization diagnostics are visible

### Key metrics
| Metric | Before | After |
|--------|--------|-------|
| Graph nodes | 147 | 147 |
| Graph edges | 0 | 5,084 |
| Solid pod access | 401 (no ACL) | 200 (WAC ACL) |
| JSS URL leaking | Internal docker URLs | Rewritten to /solid/ |
| NIP-07 detection | Fixed 2s timeout | Event-based (100ms poll) |
| RUST_LOG default | warn | info |
| Docker rebuild (code-only) | ~43 min (full) | ~8 min (cached) |

## Test plan
- [x] `cargo check` passes
- [x] `cargo build --release` passes (5m 03s)
- [x] Docker image builds successfully (43 min from scratch, ~8 min cached)
- [x] Container starts, GraphStateActor loads 147 nodes + 5,084 edges
- [x] API at `/api/graph/data` returns 147 nodes and 5,084 edges
- [x] `/api/solid/health` returns healthy
- [x] `/solid/` returns LDP listing with rewritten URLs (no internal docker hostnames)
- [x] `updates-via` header rewritten from `ws://jss:3030` to `/solid/`
- [x] INFO-level logs visible during startup sequence
- [x] Verified via live site `https://www.visionflow.info`
