### PR TITLE
fix(auth): NIP-98 validation, WAC parser, singleton NIP-07 detection

### DIFF
--- a/client/src/services/SolidPodService.ts
+++ b/client/src/services/SolidPodService.ts
@@ -763,6 +763,11 @@ class SolidPodService {
       return path;
     }
 
+    // Already resolved to proxy path — don't double-prefix
+    if (path.startsWith(JSS_BASE_URL + '/') || path === JSS_BASE_URL) {
+      return path;
+    }
+
     // Remove leading slash if present
     const cleanPath = path.startsWith('/') ? path.slice(1) : path;
     return `${JSS_BASE_URL}/${cleanPath}`;


### PR DESCRIPTION
## Summary

- **fix(solid): use X-Forwarded-URI in proxy NIP-98 validation** - `extract_user_identity()` was using the internal `/api/solid/...` path instead of the original `/solid/...` path from nginx, causing NIP-98 URL mismatch for authenticated requests
- **fix(auth): singleton waitForNip07 prevents window.nostr destruction** - Two concurrent `waitForNip07()` calls from `initialize()` and `useNostrAuth` hook installed competing `Object.defineProperty` hooks on `window.nostr`, with the first cleanup restoring it to `undefined`
- **fix(solid): WAC parser handles bare JSON arrays** - JSS stores ACLs as bare JSON arrays after Turtle-to-JSON-LD conversion, but `parseAcl()` wrapped them in another array, yielding zero parsed authorizations and 401 errors

## Root Cause

Pod browser was returning 401 "Authentication required" for logged-in users. The primary cause was the WAC parser failing to parse ACL documents stored as bare JSON arrays (not wrapped in `@graph`). Secondary issues included NIP-98 URL path mismatch in the Rust proxy and a race condition destroying `window.nostr` on the client.

## Test plan

- [x] Verified pod browser shows contents (inbox, private, profile, public, Settings, .acl) after login
- [x] Tested NIP-98 signed requests pass validation through nginx proxy
- [x] Confirmed NIP-07 extension detection works without race condition
- [ ] Test write operations to pod (create/update files)
- [ ] Test with multiple browser tabs (singleton pattern)

Co-Authored-By: claude-flow <ruv@ruv.net>
